### PR TITLE
Visual update

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@turf/bbox": "^3.7.5",
     "@turf/difference": "^3.7.5",
     "@turf/intersect": "^3.7.5",
-    "D3.TimeSlider": "^1.5.1",
+    "D3.TimeSlider": "^1.5.2",
     "backbone": "^1.3.3",
     "backbone-nested": "^2.0.4",
     "backbone.marionette": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@turf/bbox": "^3.7.5",
     "@turf/difference": "^3.7.5",
     "@turf/intersect": "^3.7.5",
-    "D3.TimeSlider": "^1.5.2",
+    "D3.TimeSlider": "^1.6.0",
     "backbone": "^1.3.3",
     "backbone-nested": "^2.0.4",
     "backbone.marionette": "^2.4.5",

--- a/src/core/views/TimeSliderView.js
+++ b/src/core/views/TimeSliderView.js
@@ -71,7 +71,7 @@ const TimeSliderView = Marionette.ItemView.extend(/** @lends core/views.TimeSlid
     this.displayInterval = options.displayInterval;
     this.selectableInterval = options.selectableInterval;
     this.maxTooltips = options.maxTooltips;
-
+    this.timeSliderAlternativeBrush = options.timeSliderAlternativeBrush;
     this.maxMapInterval = options.maxMapInterval;
     this.enableDynamicHistogram = options.enableDynamicHistogram;
     this.previousSearches = {};
@@ -97,6 +97,7 @@ const TimeSliderView = Marionette.ItemView.extend(/** @lends core/views.TimeSlid
       datasets: [],
       constrain: this.constrainTimeDomain,
       controls: this.timeSliderControls,
+      alternativeBrush: this.timeSliderAlternativeBrush,
       displayLimit: this.displayInterval,
       selectionLimit: this.selectableInterval,
       recordFilter: this.createRecordFilter(this.mapModel.get('bbox')),
@@ -270,6 +271,7 @@ const TimeSliderView = Marionette.ItemView.extend(/** @lends core/views.TimeSlid
       highlightFillColor: this.highlightFillColor,
       highlightStrokeColor: this.highlightStrokeColor,
       source,
+      noBorder: layerModel.get('noTimeSliderBorder'),
       bucket: layerModel.get('search.lightweightBuckets'),
       bucketSource,
       histogramThreshold: layerModel.get('search.histogramThreshold'),

--- a/src/core/views/layers/LayerListItemView.js
+++ b/src/core/views/layers/LayerListItemView.js
@@ -115,9 +115,11 @@ const LayerListItemView = Marionette.ItemView.extend(/** @lends core/views/layer
 
   onPopoverHidden() {
     this.isPopoverShown = false;
-    this.$slider.off('slide');
-    this.$slider.off('change');
-    this.$slider.slider('destroy');
+    if (typeof this.$slider !== 'undefined') {
+      this.$slider.off('slide');
+      this.$slider.off('change');
+      this.$slider.slider('destroy');
+    }
   },
 
   onLayerVisibleChange() {
@@ -131,7 +133,11 @@ const LayerListItemView = Marionette.ItemView.extend(/** @lends core/views/layer
   onModelChange(model) {
     // TODO: other fields required too?
     this.$('.layer-visible').prop('checked', model.get('display.visible'));
-  }
+  },
+
+  hidePopover() {
+    this.$popoverButton.popover('hide');
+  },
 });
 
 export default LayerListItemView;

--- a/src/core/views/layers/LayerListView.js
+++ b/src/core/views/layers/LayerListView.js
@@ -55,6 +55,7 @@ const LayerListView = Marionette.CollectionView.extend(/** @lends core/views/lay
 
   onSortStop() {
     // get the new order of the layers from the DOM
+    this.children.call('hidePopover');
     this.children
       .map(view => [
         view.$('.input-group').attr('id').substr(11),


### PR DESCRIPTION
- d3.TimeSlider to 1.5.2
- support noBorder and alternativeBrush options for timeslider
- hide opacity slider when layer order changes in layer list
- needs merge of https://github.com/EOX-A/d3.TimeSlider/pull/25 and a new version release