### PR TITLE
Get eo coverageset

### DIFF
--- a/src/core/views/RecordItemView.js
+++ b/src/core/views/RecordItemView.js
@@ -72,7 +72,7 @@ const RecordItemView = Marionette.ItemView.extend(/** @lends core/views/layers.R
       if (feature) {
         const id = this.model.get('id');
         if (Array.isArray(feature)) {
-          isHighlighted = !!feature.find(f => f.id === id);
+          isHighlighted = !!feature.find(f => f && f.id === id);
         } else {
           isHighlighted = (id === feature.id);
         }

--- a/src/download/eowcs.js
+++ b/src/download/eowcs.js
@@ -98,6 +98,177 @@ function getCoverageXML(coverageid, options = {}) {
   return params.join('');
 }
 
+function getEOCoverageSetXML(eoids, options = {}) {
+  let subsetX = options.subsetX;
+  let subsetY = options.subsetY;
+
+  if (!eoids) {
+    throw new Error('Parameters "coverageid" is mandatory.');
+  }
+  if (!options.package) {
+    throw new Error('Parameters "packageFormat" is missing.');
+  }
+  const subsetCRS = options.subsetCRS || 'http://www.opengis.net/def/crs/EPSG/0/4326';
+  const params = [
+    `<wcseo:GetEOCoverageSet xmlns:wcseo="http://www.opengis.net/wcs/wcseo/1.1" xmlns:wcs="http://www.opengis.net/wcs/2.0" xmlns:int="http://www.opengis.net/wcs/interpolation/1.0" xmlns:scal="http://www.opengis.net/wcs/scaling/1.0" xmlns:crs="http://www.opengis.net/wcs/crs/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs/wcseo/1.1 http://schemas.opengis.net/wcs/wcseo/1.1/wcsEOAll.xsd" service="WCS" version="2.0.1">
+     <wcseo:eoId>${eoids}</wcseo:eoId>`,
+  ];
+  const extension = [];
+
+  let axisNames;
+  if (!options.axisNames) {
+    axisNames = {
+      x: 'x',
+      y: 'y',
+    };
+  } else if (Array.isArray(options.axisNames)) {
+    axisNames = {
+      x: options.axisNames[0],
+      y: options.axisNames[1],
+    };
+  } else {
+    axisNames = options.axisNames;
+  }
+
+  if (options.package) {
+    params.push(`<wcs:format>${options.package}</wcs:format>`);
+  }
+  // if (options.package) {
+  //   params.push(`<wcseo:packageFormat>${options.package}</wcseo:packageFormat>`);
+  // }
+  if (options.bbox && !options.subsetX && !options.subsetY) {
+    subsetX = [options.bbox[0], options.bbox[2]];
+    subsetY = [options.bbox[1], options.bbox[3]];
+  }
+  if (subsetX) {
+    params.push(`<wcs:DimensionTrim><wcs:Dimension>${axisNames.x}</wcs:Dimension>
+                   <wcs:TrimLow>${subsetX[0]}</wcs:TrimLow>
+                   <wcs:TrimHigh>${subsetX[1]}</wcs:TrimHigh>
+                 </wcs:DimensionTrim>`);
+  }
+  if (subsetY) {
+    params.push(`<wcs:DimensionTrim><wcs:Dimension>${axisNames.y}</wcs:Dimension>
+                   <wcs:TrimLow>${subsetY[0]}</wcs:TrimLow>
+                   <wcs:TrimHigh>${subsetY[1]}</wcs:TrimHigh>
+                 </wcs:DimensionTrim>`);
+  }
+
+  if (options.outputCRS) {
+    extension.push(`<wcscrs:outputCrs>${options.outputCRS}</wcscrs:outputCrs>`);
+  }
+
+  if (options.sizeX && options.sizeY) {
+    extension.push(`
+      <scal:ScaleToSize>
+        <scal:TargetAxisSize>
+          <scal:axis>${axisNames.x}</scal:axis>
+          <scal:targetSize>${options.sizeX}</scal:targetSize>
+        </scal:TargetAxisSize>
+        <scal:TargetAxisSize>
+          <scal:axis>${axisNames.y}</scal:axis>
+          <scal:targetSize>${options.sizeY}</scal:targetSize>
+        </scal:TargetAxisSize>
+      </scal:ScaleToSize>
+    `);
+  }
+
+  extension.push(`<wcscrs:subsettingCrs>${subsetCRS}</wcscrs:subsettingCrs>`);
+
+
+  if (options.scale) {
+    extension.push(`<scal:ScaleByFactor><scal:scaleFactor>${options.scale}</scal:scaleFactor></scal:ScaleByFactor>`);
+  }
+
+  if (options.interpolation) {
+    extension.push(`<int:Interpolation><int:globalInterpolation>${options.interpolation}</int:globalInterpolation></int:Interpolation>`);
+  }
+
+  if (options.multipart) {
+    params.push('<wcs:mediaType>multipart/related</wcs:mediaType>');
+  }
+
+  params.push('</wcseo:GetEOCoverageSet>');
+  return params.join('');
+}
+
+function getEOCoverageSetKVP(eoids, options = {}) {
+  const params = [
+    ['service', 'WCS'],
+    ['version', '2.0.1'],
+    ['request', 'GetEOCoverageSet'],
+    ['eoid', eoids],
+  ];
+
+  const subsetCRS = options.subsetCRS || 'http://www.opengis.net/def/crs/EPSG/0/4326';
+
+  // if (options.format) {
+  //   params.push(['format', options.format]);
+  // }
+
+  if (options.package) {
+    params.push(['format', options.package]);
+  }
+
+
+  let axisNames;
+  if (!options.axisNames) {
+    axisNames = {
+      x: 'x',
+      y: 'y',
+    };
+  } else if (Array.isArray(options.axisNames)) {
+    axisNames = {
+      x: options.axisNames[0],
+      y: options.axisNames[1],
+    };
+  } else {
+    axisNames = options.axisNames;
+  }
+
+  let subsetX = options.subsetX;
+  let subsetY = options.subsetY;
+  if (options.bbox && !options.subsetX && !options.subsetY) {
+    subsetX = [options.bbox[0], options.bbox[2]];
+    subsetY = [options.bbox[1], options.bbox[3]];
+  }
+  if (subsetX) {
+    params.push(['subset', `${axisNames.x || 'x'}(${subsetX[0]},${subsetX[1]})`]);
+  }
+  if (subsetY) {
+    params.push(['subset', `${axisNames.y || 'y'}(${subsetY[0]},${subsetY[1]})`]);
+  }
+
+  if (options.outputCRS) {
+    params.push(['outputCRS', options.outputCRS]);
+  }
+  if (subsetCRS && (subsetX || subsetY)) {
+    params.push(['subsettingCRS', subsetCRS]);
+  }
+  if (options.multipart) {
+    params.push(['mediatype', 'multipart/related']);
+  }
+
+  if (options.rangeSubset) {
+    params.push(['rangesubset', options.rangeSubset.join(',')]);
+  }
+
+  // scaling related stuff
+  if (options.scale) {
+    params.push(['scaleFactor', options.scale]);
+  }
+  if (options.sizeX && options.sizeY) {
+    params.push(['scaleSize', `${axisNames.x}(${options.sizeX}),${axisNames.y}(${options.sizeY})`]);
+  }
+
+  if (options.interpolation) {
+    params.push(['interpolation', options.interpolation]);
+  }
+
+  return params
+    .map(param => param.join('='))
+    .join('&');
+}
+
 function getCoverageKVP(coverageid, options = {}) {
   const params = [
     ['service', 'WCS'],
@@ -237,7 +408,23 @@ export function download(layerModel, filtersModel, recordModel, options) {
   }
   return getCoverageXML(recordModel.get('id'), requestOptions);
 }
+export function multiDownload(layerModel, options) {
+  const requestOptions = {
+    // bbox: filtersModel.get('area'),
+    outputCRS: options.outputCRS,
+    subsetCRS: options.subsetCRS,
+    format: options.format,
+    package: options.package,
+    scale: options.scale,
+    interpolation: options.interpolation,
+  };
+  // use sizes directly
+  requestOptions.sizeX = options.sizeX;
+  requestOptions.sizeY = options.sizeY;
 
+  //return getEOCoverageSetXML(layerModel, requestOptions);
+  return getEOCoverageSetKVP(layerModel, requestOptions);
+}
 export function getDownloadInfos(layerModel, filtersModel, recordModel, options = {}) {
   const kvp = getCoverageKVP(
     recordModel.get('id'), {

--- a/src/download/index.js
+++ b/src/download/index.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { saveAs } from 'file-saver';
 
-import { download as downloadEOWCS, getDownloadInfos as getDownloadInfosEOWCS, downloadFullResolution } from './eowcs';
+import { download as downloadEOWCS, multiDownload as dowloadEOSet, getDownloadInfos as getDownloadInfosEOWCS, downloadFullResolution } from './eowcs';
 import { getDownloadInfos as getDownloadInfosUrl } from './url';
 import { getDownloadInfos as getDownloadInfosS3 } from './s3';
 import rewrite from './rewrite';
@@ -78,6 +78,27 @@ export function downloadRecord(layerModel, filtersModel, recordModel, options) {
       downloadUrl(rewrite(info.href, rewriteRule, recordModel));
     }));
   }
+}
+
+export function downloadMultipleRecords(layerModel, url, options) {
+
+
+
+  const urlOrElement = dowloadEOSet(layerModel, options);
+  downloadUrl(url + '?' + urlOrElement);
+  // if (urlOrElement) {
+
+  //   const form = $(`<form method="post" action="${url}" enctype="text/plain" target="_blank">
+  //     <input type="hidden" name='<?xml version' value='"1.0"?>${urlOrElement}'></input>
+  //   </form>`);
+  //   if (form) {
+  //     const elem = form[0];
+  //     document.body.appendChild(elem);
+  //     elem.submit();
+  //     setTimeout(() => elem.remove(), 10000);
+  //   }
+  // }
+
 }
 
 export function downloadFullResolutionWCS(layerModel, mapModel, filtersModel, options) {

--- a/src/download/models/DownloadOptionsModel.js
+++ b/src/download/models/DownloadOptionsModel.js
@@ -9,6 +9,13 @@ export default Backbone.Model.extend({
       name: 'PNG',
       mimeType: 'image/png',
     }],
+    availableMultiDownloadFormats: [{
+      name: 'ZIP',
+      mimeType: 'application/zip',
+    }, {
+      name: 'TAR',
+      mimeType: 'application/tar',
+    }],
     selectedDownloadFormat: null,
 
     availableProjections: [{
@@ -27,5 +34,7 @@ export default Backbone.Model.extend({
     selectedInterpolation: null,
 
     subsetByBounds: false,
+
+    useMultipleDownload: false,
   }
 });

--- a/src/download/views/DownloadOptionsModalView.css
+++ b/src/download/views/DownloadOptionsModalView.css
@@ -1,3 +1,6 @@
 .spacer {
   margin-top: 20px;
 }
+input.use-multiple-download {
+  margin-top: -2px;
+}

--- a/src/download/views/DownloadOptionsModalView.hbs
+++ b/src/download/views/DownloadOptionsModalView.hbs
@@ -8,6 +8,18 @@
       {{#if downloadOptions}}
         <form class="form-horizontal">
           <div class="form-group">
+             <div class="col-sm-2">
+              <label class="control-label">{{t 'Download Method'}}</label>
+            </div>
+            <div class="col-sm-10">
+              <div class="checkbox">
+            <label>
+              <input type="checkbox" class="use-multiple-download" {{#if useMultipleDownload}}checked="checked"{{/if}}>{{t 'Download multiple files vie GetEOCoverageSet'}}
+            </label>
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
             <div class="col-sm-2">
               <label class="control-label">{{t 'Bounding Box'}}</label>
             </div>
@@ -47,6 +59,21 @@
             </div>
           </div>
           {{/if}}
+          {{#if availableMultiDownloadFormats.length}}
+          <div class="form-group" disabled="disabled">
+            <div class="col-sm-2">
+              <label class="control-label">{{t 'Package'}}</label>
+            </div>
+            <div class="col-sm-10">
+              <select class="form-control select-package" disabled="disabled">
+                <option>---</option>
+                {{#each availableMultiDownloadFormats}}
+                <option value="{{this.mimeType}}">{{this.name}}</option>
+                {{/each}}
+              </select>
+            </div>
+          </div>
+          {{/if}}
           {{#if availableDownloadFormats.length}}
           <div class="form-group">
             <div class="col-sm-2">
@@ -76,7 +103,7 @@
               </select>
             </div>
           </div>
-          {{/if}}          
+          {{/if}}
           <div class="form-group">
             <div class="col-sm-2">
               <label class="control-label">{{t 'Scaling'}}</label>
@@ -93,7 +120,7 @@
             <div class="col-sm-offset-2 col-sm-4">
               <div class="radio">
                 <label>
-                  <input type="radio" name="scale-method" value="resolution"><span>{{t 'Resolution'}} <small>({{#if projection_4326}}{{t 'In decimal degrees'}}{{/if}}
+                  <input type="radio" class="scale-resolution" name="scale-method" value="resolution"><span>{{t 'Resolution'}} <small>({{#if projection_4326}}{{t 'In decimal degrees'}}{{/if}}
                     {{#unless projection_4326}}{{t 'In map units'}}{{/unless}})
                   </small></span>
                 </label>

--- a/src/download/views/DownloadOptionsModalView.js
+++ b/src/download/views/DownloadOptionsModalView.js
@@ -9,7 +9,7 @@ import './DownloadOptionsModalView.css';
 
 import FiltersModel from '../../core/models/FiltersModel';
 
-import { downloadRecord } from '../../download';
+import { downloadRecord, downloadMultipleRecords } from '../../download';
 import { getProjectionOl } from '../../contrib/OpenLayers/utils';
 
 export default ModalView.extend({
@@ -26,6 +26,7 @@ export default ModalView.extend({
   onRender() {
     const preferences = this.getPreferences();
     const preferredFormat = preferences.preferredFormat;
+    const preferredPackage = preferences.preferredPackage;
     const preferredInterpolation = preferences.preferredInterpolation;
     const preferredProjection = preferences.preferredProjection;
     const preferredScalingMethod = preferences.preferredScalingMethod;
@@ -33,10 +34,19 @@ export default ModalView.extend({
     const preferredResolution = preferences.preferredResolution;
     const preferredScale = preferences.preferredScale;
     const subsetByBounds = preferences.subsetByBounds;
+    const useMultipleDownload = preferences.UseMultipleDownload
 
     if (subsetByBounds) {
       this.$('.subset-by-bounds').prop('checked', true);
       this.model.set('subsetByBounds', subsetByBounds);
+    }
+    if (useMultipleDownload) {
+      this.$('.use-multiple-download').prop('checked', true);
+      this.model.set('useMultipleDownload', useMultipleDownload);
+    }
+    if (preferredPackage) {
+      this.$('.select-package').val(preferredPackage);
+      this.model.set('selectedDownloadPackage', preferredPackage);
     }
     if (preferredFormat) {
       this.$('.select-format').val(preferredFormat);
@@ -69,8 +79,10 @@ export default ModalView.extend({
   events: {
     'change .select-projection': 'onProjectionChange',
     'change .select-format': 'onFormatChange',
+    'change .select-package': 'onPackageChange',
     'change .select-interpolation': 'onInterpolationChange',
     'change .subset-by-bounds': 'onSubsetByBoundsChange',
+    'change .use-multiple-download': 'onUseMultipleDownload',
     'click .start-download': 'onStartDownloadClicked',
     'click .btn-draw-bbox': 'onDrawBBoxClicked',
     'change .show-bbox': 'onBBoxInputChange',
@@ -129,6 +141,11 @@ export default ModalView.extend({
     const val = this.$('.select-format').val();
     this.model.set('selectedDownloadFormat', (val !== '' && val !== '---') ? val : null);
     this.updatePreferences('preferredFormat', (val !== '' && val !== '---') ? val : null);
+  },
+  onPackageChange() {
+    const val = this.$('.select-package').val();
+    this.model.set('selectedDownloadPackage', (val !== '' && val !== '---') ? val : null);
+    this.updatePreferences('preferredPackage', (val !== '' && val !== '---') ? val : null);
   },
 
   onInterpolationChange() {
@@ -229,6 +246,23 @@ export default ModalView.extend({
     this.updatePreferences('subsetByBounds', checked);
   },
 
+  onUseMultipleDownload() {
+    const checked = this.$('.use-multiple-download').is(':checked');
+    this.model.set('useMultipleDownload', checked);
+    this.updatePreferences('useMultipleDownload', checked);
+    this.$('.select-package').prop('disabled', !checked);
+    this.$('.select-format').prop('disabled', checked);
+    this.$('.select-interpolation').prop('disabled', checked);
+    this.$('.subset-by-bounds').prop('disabled', checked);
+    this.$('.scale-resolution').prop('disabled', checked);
+
+    if (checked){
+      this.$('.select-format').val('---');
+
+      this.$('.select-interpolation').val('---');
+    }
+
+  },
   getPreferences() {
     try {
       return JSON.parse(localStorage.getItem(
@@ -291,6 +325,7 @@ export default ModalView.extend({
     }
     const options = {
       format: this.model.get('selectedDownloadFormat'),
+      package: this.model.get('selectedDownloadPackage'),
       outputCRS: this.model.get('selectedProjection'),
       subsetCRS: subsetProj,
       interpolation: this.model.get('selectedInterpolation'),
@@ -333,6 +368,19 @@ export default ModalView.extend({
         break;
     }
 
+    let GetEOCoverageSet = this.model.get('useMultipleDownload')
+    if (GetEOCoverageSet){
+      let eoids= []
+      var url
+      this.records.forEach(([recordModel, searchModel], i) => {
+        if (i === 0){
+          url = searchModel.get('layerModel').get('download.url')
+        }
+        eoids.push(recordModel.id)
+      }
+      );
+      downloadMultipleRecords(eoids, url, options)
+    }else{
     // if EO-WCS, use a timeout
     const timeout = this.showDownloadOptions ? 500 : 0;
     this.records.forEach(([recordModel, searchModel], i) => {
@@ -341,5 +389,6 @@ export default ModalView.extend({
           searchModel.get('layerModel'), filtersModel, recordModel, options), i * timeout
       );
     });
+    }
   }
 });

--- a/src/download/views/DownloadSelectionView.js
+++ b/src/download/views/DownloadSelectionView.js
@@ -15,6 +15,7 @@ const DownloadView = Marionette.CompositeView.extend({
       termsAndConditionsUrl: this.termsAndConditionsUrl,
       downloadEnabled: this.downloadEnabled,
       selectFilesEnabled: typeof this.onSelectFiles !== 'undefined',
+      enableGetEOCoverageSet: this.enableGetEOCoverageSet,
     };
   },
   className: 'download-view',
@@ -52,6 +53,7 @@ const DownloadView = Marionette.CompositeView.extend({
     this.termsAndConditionsUrl = options.termsAndConditionsUrl;
     this.downloadEnabled = options.downloadEnabled;
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
+    this.enableGetEOCoverageSet = options.enableGetEOCoverageSet;
 
     this.collection.each((searchModel) => {
       this.listenTo(
@@ -60,6 +62,7 @@ const DownloadView = Marionette.CompositeView.extend({
     });
     this.onSelectFiles = options.onSelectFiles;
     this.onStartDownload = options.onStartDownload;
+    this.onMultiDownload = options.onMultiDownload;
   },
 
   onChildBeforeRender() {


### PR DESCRIPTION
- adding support of WCS GetEOCoverageSet operation for KVP
- new options:
-- `enableGetEOCoverageSet: boolean`, enables selection list in download options in case multiple items are selected
- `multiDownloadFormats`: object with options to add as parameters as download format of GetEOCoverageSet: 
```html
"multiDownloadFormats": [
            {
                "name": "ZIP",
                "mimeType": "application/zip"
            },
            {
                "name": "TAR",
                "mimeType": "application/tar"
            },
        ],
```