### PR TITLE
Coverage ids

### DIFF
--- a/src/download/eowcs.js
+++ b/src/download/eowcs.js
@@ -198,7 +198,6 @@ function getEOCoverageSetKVP(eoids, options = {}) {
     ['version', '2.0.1'],
     ['request', 'GetEOCoverageSet'],
     ['eoid', eoids],
-    // ['count', eoids.length],
   ];
 
   const subsetCRS = options.subsetCRS || 'http://www.opengis.net/def/crs/EPSG/0/4326';
@@ -410,6 +409,7 @@ export function download(layerModel, filtersModel, recordModel, options) {
   }
   return getCoverageXML(recordModel.get('id'), requestOptions);
 }
+
 export function multiDownload(layerModel, filtersModel, options) {
   const requestOptions = {
     bbox: filtersModel.get('area'),
@@ -424,9 +424,9 @@ export function multiDownload(layerModel, filtersModel, options) {
   requestOptions.sizeX = options.sizeX;
   requestOptions.sizeY = options.sizeY;
 
-  //return getEOCoverageSetXML(layerModel, requestOptions);
   return getEOCoverageSetKVP(layerModel, requestOptions);
 }
+
 export function getDownloadInfos(layerModel, filtersModel, recordModel, options = {}) {
   const kvp = getCoverageKVP(
     recordModel.get('id'), {

--- a/src/download/index.js
+++ b/src/download/index.js
@@ -81,24 +81,8 @@ export function downloadRecord(layerModel, filtersModel, recordModel, options) {
 }
 
 export function downloadMultipleRecords(layerModel, url, filterModel, options) {
-
-
-
   const urlOrElement = dowloadEOSet(layerModel, filterModel, options);
   downloadUrl(url + '?' + urlOrElement);
-  // if (urlOrElement) {
-
-  //   const form = $(`<form method="post" action="${url}" enctype="text/plain" target="_blank">
-  //     <input type="hidden" name='<?xml version' value='"1.0"?>${urlOrElement}'></input>
-  //   </form>`);
-  //   if (form) {
-  //     const elem = form[0];
-  //     document.body.appendChild(elem);
-  //     elem.submit();
-  //     setTimeout(() => elem.remove(), 10000);
-  //   }
-  // }
-
 }
 
 export function downloadFullResolutionWCS(layerModel, mapModel, filtersModel, options) {

--- a/src/download/models/DownloadOptionsModel.js
+++ b/src/download/models/DownloadOptionsModel.js
@@ -36,5 +36,7 @@ export default Backbone.Model.extend({
     subsetByBounds: false,
 
     useMultipleDownload: false,
+
+    downloadLimitCount: null,
   }
 });

--- a/src/download/url.js
+++ b/src/download/url.js
@@ -44,7 +44,7 @@ export function flattenDownloadSelectionByCoverage(downloadSelections) {
     if (coverages) {
       for (let j = 0; j < coverages.length; j++) {
         // for each coverage create a copy of original OpenSearchRecordModel, replace its ID with coverageID and push it back to the records array
-        let recordClone = Object.assign(Object.create(Object.getPrototypeOf(downloadSel)), downloadSel);
+        const recordClone = $.extend(true, {}, downloadSel);
         recordClone.attributes.id = coverages[j];
         if (Array.isArray(record)) {
           records.push([recordClone, ...record]);

--- a/src/download/url.js
+++ b/src/download/url.js
@@ -25,3 +25,37 @@ export function getDownloadInfos(recordModel) {
   }
   return Promise.resolve([]);
 }
+
+/**
+ * Flattens downloadSelection list, each entry is split into individual coverages from properties.coverages
+ * if input list is a list of lists, assuming that downloadSelection will be a first item and the rest of items will be appended to the created coverage
+ * @param {Array} downloadSelections Array of OpenSearchRecordModels or of arrays, where OpenSearchRecordModel is item on index 0
+ * @returns {Array} Flattened array per coverage
+ */
+export function flattenDownloadSelectionByCoverage(downloadSelections) {
+  let records = [];
+  downloadSelections.forEach((record) => {
+    let downloadSel = record;
+    if (Array.isArray(record)) {
+      downloadSel = record.shift();
+    }
+    const coverages = downloadSel.attributes.properties.coverages;
+
+    if (coverages) {
+      for (let j = 0; j < coverages.length; j++) {
+        // for each coverage create a copy of original OpenSearchRecordModel, replace its ID with coverageID and push it back to the records array
+        let recordClone = Object.assign(Object.create(Object.getPrototypeOf(downloadSel)), downloadSel);
+        recordClone.attributes.id = coverages[j];
+        if (Array.isArray(record)) {
+          records.push([recordClone, ...record]);
+        } else {
+          records.push(recordClone);
+        }
+      }
+    } else {
+      // keep original entry
+      records.push(downloadSel);
+    }
+  });
+  return records;
+}

--- a/src/download/views/DownloadOptionsModalView.hbs
+++ b/src/download/views/DownloadOptionsModalView.hbs
@@ -173,7 +173,7 @@
       {{#if records.[1]}}
           {{#if records.[2]}}
             <p class="multi-download-confirm" hidden="true">
-              <i>{{t 'products_number_warning'}}</i>
+              {{t 'products_number_warning' }}
             </p>
             <p class="download-confirm">
               <i>{{t 'confirm_note'}}</i>

--- a/src/download/views/DownloadOptionsModalView.js
+++ b/src/download/views/DownloadOptionsModalView.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import { transformExtent } from 'ol/proj';
 import ModalView from '../../core/views/ModalView';
+import i18next from 'i18next';
 
 import template from './DownloadOptionsModalView.hbs';
 import './DownloadOptionsModalView.css';
@@ -21,6 +22,7 @@ export default ModalView.extend({
       bbox: this.bbox.map(v => v.toFixed(4)),
       projection_4326: this.mapProjection.getCode() === 'EPSG:4326',
       enableGetEOCoverageSet: this.enableGetEOCoverageSet,
+      downloadLimitCount: this.model.get('downloadLimitCount'),
     };
   },
 
@@ -41,11 +43,21 @@ export default ModalView.extend({
       this.$('.subset-by-bounds').prop('checked', true);
       this.model.set('subsetByBounds', subsetByBounds);
     }
+    this.$('.multi-download-confirm').text(
+      i18next.t('products_number_warning', {
+        downloadLimitCount: this.model.get('downloadLimitCount'),
+      })
+    );
     if (useMultipleDownload) {
       this.$('.use-multiple-download').prop('checked', true);
       this.$('.downloadFormats').show();
       this.$('.download-confirm').hide();
-      this.records.length > 5 && this.$('.multi-download-confirm').show();
+      if (!isNaN(this.model.get('downloadLimitCount')) && this.records.length > this.model.get('downloadLimitCount')) {
+        this.$('.multi-download-confirm').show();
+      }
+      if (!isNaN(this.model.get('downloadLimitCount')) && this.records.length > this.model.get('downloadLimitCount')) {
+        this.$('.multi-download-confirm').show();
+      }
       this.$('.spacer').show();
       this.model.set('useMultipleDownload', useMultipleDownload);
     } else {
@@ -266,7 +278,9 @@ export default ModalView.extend({
     if (checked) {
       this.$('.downloadFormats').show();
       this.$('.download-confirm').hide();
-      this.records.length > 5 && this.$('.multi-download-confirm').show();
+      if (!isNaN(this.model.get('downloadLimitCount')) && this.records.length > this.model.get('downloadLimitCount')) {
+        this.$('.multi-download-confirm').show();
+      }
       this.$('.spacer').show();
     } else {
       this.$('.downloadFormats').hide();
@@ -408,3 +422,4 @@ export default ModalView.extend({
     }
   }
 });
+

--- a/src/download/views/DownloadOptionsModalView.js
+++ b/src/download/views/DownloadOptionsModalView.js
@@ -12,6 +12,7 @@ import FiltersModel from '../../core/models/FiltersModel';
 
 import { downloadRecord, downloadMultipleRecords } from '../../download';
 import { getProjectionOl } from '../../contrib/OpenLayers/utils';
+import { flattenDownloadSelectionByCoverage } from '../url';
 
 export default ModalView.extend({
   template,
@@ -148,6 +149,10 @@ export default ModalView.extend({
           .map(recordModel => [recordModel, searchModel]))
       ), []);
     }
+
+    // flatten the products records into per-coverage records, if coverages are set in properties
+    this.records = flattenDownloadSelectionByCoverage(this.records);
+
     this.showDownloadOptions = this.records.reduce((acc, record) => (
       acc || record[1].get('layerModel').get('download.protocol') === 'EO-WCS'
     ), false);

--- a/src/download/views/DownloadSelectionView.js
+++ b/src/download/views/DownloadSelectionView.js
@@ -7,6 +7,7 @@ import './DownloadSelectionView.css';
 import SelectionListView from './SelectionListView';
 import { downloadCustom, getDownloadInfos } from '../../download/';
 import metalinkTemplate from '../Metalink.hbs';
+import { flattenDownloadSelectionByCoverage } from '../url';
 
 const DownloadView = Marionette.CompositeView.extend({
   template,
@@ -225,14 +226,14 @@ const DownloadView = Marionette.CompositeView.extend({
       return arr.reduce((acc, val) => acc.concat(val), []);
     }
 
-
     const chunks = this.collection
-      .map(searchModel =>
-        searchModel.get('downloadSelection')
+      .map(searchModel => {
+        const records = flattenDownloadSelectionByCoverage(searchModel.get('downloadSelection'));
+        return records
           .map(recordModel => getDownloadInfos(
             searchModel.get('layerModel'), this.filtersModel, recordModel, options)
           )
-      );
+        });
 
     return Promise.all(flatten(chunks))
       .then(received => flatten(received));

--- a/src/search/opensearch/index.js
+++ b/src/search/opensearch/index.js
@@ -100,9 +100,6 @@ export function searchAllRecords(layerModel, filtersModel, mapModel, options = {
   }]);
 
   worker.onmessage = ({ data }) => {
-    // TODO: DELETE ME
-//    data[1].records.forEach(
-//      element => element.properties.coverages = [element.properties.title + "__DEM1__coverage", element.properties.title + "__DEM1__coverage"]);
     emitter.emit(...data);
   };
 

--- a/src/search/opensearch/index.js
+++ b/src/search/opensearch/index.js
@@ -100,6 +100,9 @@ export function searchAllRecords(layerModel, filtersModel, mapModel, options = {
   }]);
 
   worker.onmessage = ({ data }) => {
+    // TODO: DELETE ME
+//    data[1].records.forEach(
+//      element => element.properties.coverages = [element.properties.title + "__DEM1__coverage", element.properties.title + "__DEM1__coverage"]);
     emitter.emit(...data);
   };
 


### PR DESCRIPTION
 * Flattens downloadSelection list, each entry is split into individual coverages from item.properties.coverages
 * if input list is a list of lists, assuming that downloadSelection will be a first item and the rest of items will be appended to the created coverage

Used in product download - downloads all coverages from a product