### PR TITLE
Concurrency queue

### DIFF
--- a/src/core/util.js
+++ b/src/core/util.js
@@ -162,3 +162,12 @@ export function setSearchParam(key, value) {
 export function numberThousandSep(x, sep) {
   return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, sep);
 }
+
+export function isValidUrl(urlString) {
+  try { 
+    return Boolean(new URL(urlString)); 
+  }
+  catch(e){ 
+    return false; 
+  }
+}

--- a/src/core/views/RecordItemView.hbs
+++ b/src/core/views/RecordItemView.hbs
@@ -1,5 +1,5 @@
 <a href="#">
-  <img src="{{thumbnailUrl}}" alt="{{t 'trying to download thumbnail' }}">
+  <img alt="{{t 'trying to download thumbnail' }}">
 </a>
 <div>{{date}}<br/>{{time}}</div>
 <button class="btn btn-default btn-xs record-info">

--- a/src/core/views/RecordItemView.js
+++ b/src/core/views/RecordItemView.js
@@ -54,28 +54,28 @@ const RecordItemView = Marionette.ItemView.extend(/** @lends core/views/layers.R
   },
 
   setupQueueListeners() {
-    window.BackboneEventBus.on(`fetch:success:${this.usedUrl}`, this.fetchSuccessHandler, this);
-    window.BackboneEventBus.on(`fetch:failure:${this.usedUrl}`, this.fetchFailureHandler, this);
+    window.EventBusLimitedRequestQueue.on(`fetch:success:${this.usedUrl}`, this.fetchSuccessHandler, this);
+    window.EventBusLimitedRequestQueue.on(`fetch:failure:${this.usedUrl}`, this.fetchFailureHandler, this);
   },
 
   unSetupQueueListeners() {
-    window.BackboneEventBus.off(`fetch:success:${this.usedUrl}`, null, this);
-    window.BackboneEventBus.off(`fetch:failure:${this.usedUrl}`, null, this);
+    window.EventBusLimitedRequestQueue.off(`fetch:success:${this.usedUrl}`, null, this);
+    window.EventBusLimitedRequestQueue.off(`fetch:failure:${this.usedUrl}`, null, this);
   },
 
   enqueueImageFetch(url) {
-    if (window.requestQueue) {
+    if (window.LimitedRequestQueue) {
       const urlObj = new URL(url);
-      if (window.BackboneEventBus.cache[urlObj.href]) {
+      if (window.EventBusLimitedRequestQueue.cache[urlObj.href]) {
         // take thumbnail from cache and set to image element src
-        const imageBlobUrl = window.BackboneEventBus.cache[urlObj.href];
+        const imageBlobUrl = window.EventBusLimitedRequestQueue.cache[urlObj.href];
         this.setImageSrc(imageBlobUrl);
       } else {
         this.usedUrl = urlObj.href;
         this.setupQueueListeners();
-        if (!window.requestQueue.has(this.usedUrl)) {
+        if (!window.LimitedRequestQueue.has(this.usedUrl)) {
           // put item to queue
-          window.requestQueue.enqueue(urlObj, {}, {
+          window.LimitedRequestQueue.enqueue(urlObj, {}, {
             'lifo': true, 'itemID': this.usedUrl,
           });
         }
@@ -158,10 +158,10 @@ const RecordItemView = Marionette.ItemView.extend(/** @lends core/views/layers.R
   },
 
   onDestroy() {
-    if (window.requestQueue) {
+    if (window.LimitedRequestQueue) {
       // delete still present listeners, dequeue current url
       this.unSetupQueueListeners();
-      window.requestQueue.dequeue(this.usedUrl);
+      window.LimitedRequestQueue.dequeue(this.usedUrl);
     }
   },
 });

--- a/src/core/views/RecordItemView.js
+++ b/src/core/views/RecordItemView.js
@@ -2,8 +2,8 @@ import Marionette from 'backbone.marionette';
 
 import template from './RecordItemView.hbs';
 import './RecordItemView.css';
-
 import imageError from './RecordItemViewImageError.hbs';
+import { isValidUrl } from '../util';
 
 const RecordItemView = Marionette.ItemView.extend(/** @lends core/views/layers.RecordItemView# */{
   template,
@@ -21,49 +21,104 @@ const RecordItemView = Marionette.ItemView.extend(/** @lends core/views/layers.R
     this.collection = this.model.collection || options.collection;
     this.thumbnailUrlPattern = options.thumbnailUrlPattern;
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
+    this.usedUrl = null;
   },
 
   templateHelpers() {
     const time = this.model.get('properties').time;
     const start = Array.isArray(time) ? time[0] : time;
-    let thumbnailUrl = this.model.getThumbnailUrl(
-      this.collection && this.collection.searchModel ? this.collection.searchModel.get('layerModel').get('search.thumbnailUrlTemplate')
-                      : undefined
-    );
-    if (this.thumbnailUrlPattern && !(new RegExp(this.thumbnailUrlPattern)).test(thumbnailUrl)) {
-      thumbnailUrl = '';
-    }
     return {
-      thumbnailUrl,
       date: start.toISOString().substring(0, 10),
       time: start.toISOString().substring(11, 19),
     };
   },
 
-  onRender() {
+  setImageSrc(imageObjectURL) {
     const $img = this.$('img');
-    $img
-      .one('load', () => this.$('img').fadeIn('slow'))
-      .one('error', () => {
-        const quickLookUrl = this.model.getQuickLookUrl(
-          this.collection && this.collection.searchModel ? this.collection.searchModel.get('layerModel').get('search.quickLookUrlTemplate')
-                          : undefined
-        );
-        if (quickLookUrl) {
-          $img
-          .attr('src', quickLookUrl)
-          .one('load', () => this.$('img').fadeIn('slow'))
-          .one('error', () => {
-          });
-        } else if (this.fallbackThumbnailUrl) {
-          $img
-            .one('error', () => $img.attr('alt', imageError()))
-            .attr('src', this.fallbackThumbnailUrl)
-            .addClass('error');
+    $img.attr('src', imageObjectURL);
+  },
+
+  boundHandler(imageBlob) {
+    this.setImageSrc(imageBlob);
+    this.unSetupQueueListener();
+  },
+
+  setupQueueListener() {
+    const id = this.getID();
+    window.BackboneEventBus.on(`fetch:${id}`, this.boundHandler, this);
+  },
+
+  unSetupQueueListener() {
+    const id = this.getID();
+    window.BackboneEventBus.off(`fetch:${id}`, null, this);
+  },
+
+  getID() {
+    return `${this.usedUrl}`;
+  },
+
+  enqueueThumbnailImageFetch() {
+    let url = this.model.getThumbnailUrl(
+      this.collection && this.collection.searchModel ? this.collection.searchModel.get('layerModel').get('search.thumbnailUrlTemplate')
+        : undefined
+    );
+    if (this.thumbnailUrlPattern && !(new RegExp(this.thumbnailUrlPattern)).test(url)) {
+      url = '';
+    }
+    if (isValidUrl(url)) {
+      if (window.requestQueue) {
+        const urlObj = new URL(url);
+        if (window.BackboneEventBus.cache[urlObj.href]) {
+          const imageBlobUrl = window.BackboneEventBus.cache[urlObj.href];
+          this.setImageSrc(imageBlobUrl);
         } else {
-          $img.attr('alt', imageError());
+          this.usedUrl = urlObj.href;
+          this.setupQueueListener();
+          const id = this.getID();
+          if (!window.requestQueue.has(id)) {
+            window.requestQueue.enqueue(urlObj, {}, {
+              'lifo': true, 'itemID': this.getID(),
+            });
+          }
         }
-      });
+      } else {
+        fetch(url)
+          .then((response) => response.blob())
+          .then((imageBlob) => {
+            // Then create a local URL for that image
+            const imageObjectURL = URL.createObjectURL(imageBlob);
+            this.setImageSrc(imageObjectURL);
+          }).bind(this);
+      }
+
+    }
+  },
+
+  onRender() {
+    this.enqueueThumbnailImageFetch();
+    // const $img = this.$('img');
+    // $img
+    //   .one('load', () => this.$('img').fadeIn('slow'))
+    //   .one('error', () => {
+    //     const quickLookUrl = this.model.getQuickLookUrl(
+    //       this.collection && this.collection.searchModel ? this.collection.searchModel.get('layerModel').get('search.quickLookUrlTemplate')
+    //                       : undefined
+    //     );
+    //     if (quickLookUrl) {
+    //       $img
+    //       .attr('src', quickLookUrl)
+    //       .one('load', () => this.$('img').fadeIn('slow'))
+    //       .one('error', () => {
+    //       });
+    //     } else if (this.fallbackThumbnailUrl) {
+    //       $img
+    //         .one('error', () => $img.attr('alt', imageError()))
+    //         .attr('src', this.fallbackThumbnailUrl)
+    //         .addClass('error');
+    //     } else {
+    //       $img.attr('alt', imageError());
+    //     }
+    //   });
   },
 
   onAttach() {
@@ -93,6 +148,21 @@ const RecordItemView = Marionette.ItemView.extend(/** @lends core/views/layers.R
 
   onItemMouseOut() {
     this.highlightModel.unHighlight(this.model.attributes);
+  },
+
+  onDestroy() {
+    if (window.requestQueue) {
+      this.unSetupQueueListener(this.usedUrl);
+      window.requestQueue.dequeue(this.usedUrl);
+    }
+  },
+
+  onDestroy() {
+    if (window.requestQueue) {
+      this.unSetupQueueListener();
+    }
+    const id = this.getID();
+    window.requestQueue.dequeue(id);
   },
 });
 


### PR DESCRIPTION
Via upstream dependency on  [forked limited-request-queue](https://github.com/eoxc/limited-request-queue/tree/lifo) replaces the way how thumbnails are fetched and adds concurrency limitation in Search Results list.
**Previously** was via `src of img` element, so all currently seen images were fetched. That means if the list was quickly scrolled, created a queue of tens of thumbnails to fetch, which can fill the bandwidth of target server quickly.
**Now** images are put to queue in LIFO mode, where queue enables fetching of always up to 6 images in parallel - configurable but browser fetch defaults 6 can not be exceeded currently. Images are removed from queue if they the list is scrolled already past their appearance (which improves server performance for frenetically list scrolling individuals).
Also forces usage of a new client-side cache, so even when user has disabled caching, still images will be cached until he closes the window.
Implementation still supports original fetch without queue and caching in rare case, that the upstream app embedding `eoxc` decides not to define it.
Communication with upstream is done via Backbone events but without connection to existing models, but via a new EventBus.

Upstream integration can look like:

```javascript
import RequestQueue from 'limited-request-queue/lib-es5';`
window.EventBusLimitedRequestQueue = _.extend({ 'cache': {} }, Backbone.Events);
window.LimitedRequestQueue = new RequestQueue();
window.LimitedRequestQueue
  .on('item', fetchQueueItem);
```

```javascript
function fetchQueueItem(url, data, done, itemID) {
    if (window.EventBusLimitedRequestQueue.cache[url.href]) {
        const imageObjectURL = window.EventBusLimitedRequestQueue.cache[url.href];
        window.EventBusLimitedRequestQueue.trigger(`fetch:${itemID}`, imageObjectURL);
    } else {
        fetch(url)
            .then((response) => {
                if (!response.ok) {
                    window.EventBusLimitedRequestQueue.trigger(`fetch:failure:${itemID}`);
                    const error = new Error('Response status !== 20x');
                    error.name = 'CancelPromiseChainError';
                    throw error;
                }
                return response.blob();
            })
            .then((imageBlob) => {
                const imageObjectURL = URL.createObjectURL(imageBlob);
                window.EventBusLimitedRequestQueue.cache[url.href] = imageObjectURL;
                return imageObjectURL;
            })
            .then((imageObjectURL) => window.EventBusLimitedRequestQueue.trigger(`fetch:success:${itemID}`, imageObjectURL))
            .catch(error => {
                if (error.name !== 'CancelPromiseChainError') {
                    // re-raise
                    throw error;
                }
            })
            .finally(() => done())
    }
}
```

